### PR TITLE
Changed button to text with icon for modal, add svg in assets

### DIFF
--- a/src/assets/arrow-up-right-from-square-solid.svg
+++ b/src/assets/arrow-up-right-from-square-solid.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="#A670AF" className="w-4 h-4">
+  <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 003 8.25v10.5A2.25 2.25 0 005.25 21h10.5A2.25 2.25 0 0018 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25" />
+</svg>

--- a/src/components/PolicyModal.js
+++ b/src/components/PolicyModal.js
@@ -19,10 +19,10 @@ const AttendancePolicyModal = () => {
     <>
       <div onClick={()=> handleClick()}
         className="
-          hover:underline
-          text-[#A670AF]
           inline-flex
           cursor-pointer
+          text-[#A670AF]
+          hover:underline
           "
       >
         Attendance Policy
@@ -81,10 +81,10 @@ const ComprehensionModal = () => {
     <>
       <div onClick={()=> handleClick()}
         className="
-          hover:underline
-          text-[#A670AF]
           inline-flex
           cursor-pointer
+          text-[#A670AF]
+          hover:underline
           "
       >
         Comprehension Levels

--- a/src/components/PolicyModal.js
+++ b/src/components/PolicyModal.js
@@ -1,6 +1,6 @@
 import React, { useState } from "react"
 import { Modal } from "flowbite-react"
-import { Button } from "./Button"
+import arrowBox from "../assets/arrow-up-right-from-square-solid.svg"
 
 const AttendancePolicyModal = () => {
   const [visible, setVisible] = useState(false)
@@ -17,8 +17,19 @@ const AttendancePolicyModal = () => {
 
   return (
     <>
-      <div className="w-52">
-        <Button text={"Attendance Policy"} onClick={() => handleClick()} />
+      <div onClick={()=> handleClick()}
+        className="
+          hover:underline
+          text-[#A670AF]
+          inline-flex
+          cursor-pointer
+          "
+      >
+        Attendance Policy
+        <img 
+          src={arrowBox} 
+          className="ml-2 h-auto w-5"
+        />
       </div>
       <div id="modal-container" onClick={() => handleClick()}>
         <Modal
@@ -68,8 +79,19 @@ const ComprehensionModal = () => {
   
   return (
     <>
-      <div className="w-52">
-        <Button text={"Comprehension"} onClick={() => handleClick()} />
+      <div onClick={()=> handleClick()}
+        className="
+          hover:underline
+          text-[#A670AF]
+          inline-flex
+          cursor-pointer
+          "
+      >
+        Comprehension Levels
+        <img 
+          src={arrowBox} 
+          className="ml-2 h-auto w-5"
+        />
       </div>
       <div id="modal-container" onClick={() => handleClick()}>
         <Modal

--- a/src/components/PolicyModal.test.js
+++ b/src/components/PolicyModal.test.js
@@ -10,9 +10,9 @@ describe("<AttendancePolicyModal />", () => {
   beforeEach(() => {
     modalRender = shallow(<AttendancePolicyModal />)
   })
-  it("renders a button", () => {
-    const modalButton = modalRender.find("Button")
-    expect(modalButton.length).toEqual(1)
+  it("renders an icon", () => {
+    const modalIcon = modalRender.find("img")
+    expect(modalIcon.length).toEqual(1)
   } ),
   it("renders a modal", () => {
     const renderModal = modalRender.find("Modal")
@@ -25,9 +25,9 @@ describe("<ComprehensionModal />", () => {
   beforeEach(() => { 
     modalRender = shallow(<ComprehensionModal />)
   })
-  it("renders a button", () => {
-    const modalButton = modalRender.find("Button")
-    expect(modalButton.length).toEqual(1)
+  it("renders an icon", () => {
+    const modalIcon = modalRender.find("img")
+    expect(modalIcon.length).toEqual(1)
   } ),
   it("renders a modal", () => {
     const renderModal = modalRender.find("Modal")


### PR DESCRIPTION
# Submitting Pull Request

### Ticket

ID number: [50]

Branch name: looking

Description: Changed the button that opened the modals to text with an icon. Applied to both attendance policy and skill levels. Kept the purple color for text and icon. 

Link to ticket: https://www.notion.so/2022-Delta-Internship-6af24e8d3bb349ea8fe44f3d6351f036?p=6aacbedaa1e44b1caa53c4bf1875597d&pm=s

### Notes

Notes for the reviewer: It was fun to incorporate an SVG and learn a bit more about Tailwind by pair programming. 

Contributors: Luis and Gene
