### PR TITLE
Fixed bug where '3' would move to far

### DIFF
--- a/src/components/Attendance.js
+++ b/src/components/Attendance.js
@@ -26,7 +26,7 @@ const Attendance = ({absences}) => {
       </div>
       <div className="mb-1 flex justify-between">
         <span className="ml-2 font-medium text-black dark:text-white">5</span>
-        <span className="ml-2 mr-44 font-medium text-black dark:text-white">3</span>
+        <span className="ml-2 font-medium text-black dark:text-white">3</span>
         <span className="ml-2 font-medium text-black dark:text-white">Awesome</span>
       </div>
     </>


### PR DESCRIPTION
# Submitting Pull Request

### Ticket

ID number: 66

Branch name: progress-bar-bug

Description: Numbers on the bar to move dynamically with the progress bar on window resize

Link to ticket: https://www.notion.so/Student-Application-Dashboard-1333c4b5cd684d179b86f03fc61cab4f?p=a57910f1f9124407b2c35724e682fb5c&pm=c

### Notes

Notes for the reviewer:

Contributors: Luis, Will, Nicole, Gene, Ahmed
